### PR TITLE
Add support for MD5 crypt generated strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 ivy/
 lib/
 target/
+.idea/

--- a/ivy.xml
+++ b/ivy.xml
@@ -4,5 +4,7 @@
     <dependencies>
 	<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-crypto -->
 	<dependency org="org.springframework.security" name="spring-security-crypto" rev="5.1.3.RELEASE"/>
+	<!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
+	<dependency org="commons-codec" name="commons-codec" rev="1.10"/>
     </dependencies>
 </ivy-module>

--- a/src/relationalLogin/DBLogin.java
+++ b/src/relationalLogin/DBLogin.java
@@ -13,6 +13,7 @@ import javax.security.auth.callback.*;
 import javax.security.auth.login.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.apache.commons.codec.digest.Md5Crypt;
 
 /**
  * Simple database based authentication module.
@@ -29,7 +30,7 @@ public class DBLogin extends SimpleLogin
 	protected String                userTable;
 	protected String                userColumn;
 	protected String                passColumn;
-        protected String                saltColumn;
+	protected String                saltColumn;
 	protected String                where;
 
 	private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
@@ -65,10 +66,15 @@ public class DBLogin extends SimpleLogin
                         if (hashingAlg != null && (!hashingAlg.isEmpty())) {
 
 			    if (hashingAlg.toLowerCase().equals("bcrypt")) {
-                               tpwd = new String(password);
-			       String upwd2 = "$2a" + upwd.substring(3);
-                               if (!passwordEncoder.matches(tpwd, upwd2)) throw new FailedLoginException(getOption("errorMessage", "Invalid details (b)"));
-			    } else {
+					tpwd = new String(password);
+					String upwd2 = "$2a" + upwd.substring(3);
+					if (!passwordEncoder.matches(tpwd, upwd2))
+						throw new FailedLoginException(getOption("errorMessage", "Invalid details (b)"));
+				} else if (hashingAlg.toLowerCase().equals("md5crypt")) {
+					tpwd = new String(password);
+					/* Check the password */
+					if (!upwd.equals(Md5Crypt.md5Crypt(tpwd.getBytes(), upwd))) throw new FailedLoginException(getOption("errorMessage", "Invalid details"));
+				} else {
                                try {
                                    tpwd = this.hash(new String(password) + salt, hashingAlg);  
                                } catch (NoSuchAlgorithmException ex) {


### PR DESCRIPTION
This was a super easy change to implement.  Maybe this is too specific to our institution for inclusion in the general release, but it could probably be pretty easily extended to allow the IDP to authenticate against the SQL tables generated by Apache HTTPd's mod_auth_dbd.

There are some whitespace only changes that snuck in.  I'm not sure why.