### PR TITLE
migrate md5 crypt to plain old crypt; remove unused cryptPassword()

### DIFF
--- a/src/relationalLogin/DBLogin.java
+++ b/src/relationalLogin/DBLogin.java
@@ -13,7 +13,8 @@ import javax.security.auth.callback.*;
 import javax.security.auth.login.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.apache.commons.codec.digest.Md5Crypt;
+import org.apache.commons.codec.digest.Crypt;
+
 
 /**
  * Simple database based authentication module.
@@ -70,10 +71,10 @@ public class DBLogin extends SimpleLogin
 					String upwd2 = "$2a" + upwd.substring(3);
 					if (!passwordEncoder.matches(tpwd, upwd2))
 						throw new FailedLoginException(getOption("errorMessage", "Invalid details (b)"));
-				} else if (hashingAlg.toLowerCase().equals("md5crypt")) {
+				} else if (hashingAlg.toLowerCase().equals("crypt")) {
 					tpwd = new String(password);
 					/* Check the password */
-					if (!upwd.equals(Md5Crypt.md5Crypt(tpwd.getBytes(), upwd))) throw new FailedLoginException(getOption("errorMessage", "Invalid details"));
+					if (!upwd.equals(Crypt.crypt(tpwd.getBytes(), salt))) throw new FailedLoginException(getOption("errorMessage", "Invalid details"));
 				} else {
                                try {
                                    tpwd = this.hash(new String(password) + salt, hashingAlg);  

--- a/src/relationalLogin/Utils.java
+++ b/src/relationalLogin/Utils.java
@@ -12,9 +12,6 @@ import java.security.*;
  */
 public class Utils
 {
-	private final static String     ALGORITHM   = "MD5";
-	private static MessageDigest    md = null;
-
 	/**
 	 * Can't make these: all the methods are static
 	 */
@@ -75,27 +72,5 @@ public class Utils
 				pwd[b] = 0;
 			}
 		}
-	}
-
-	/**
-	 * Perform MD5 hashing on the supplied password and return a char array
-	 * containing the encrypted password as a printable string. The hash is
-	 * computed on the low 8 bits of each character.
-	 *
-	 * @param pwd The password to encrypt
-	 * @return a character array containing a 32 character long hex encoded
-	 * MD5 hash of the password
-	 */
-	public static char[] cryptPassword(char pwd[]) throws Exception
-	{
-		if (null == md) { md = MessageDigest.getInstance(ALGORITHM); }
-		md.reset();
-		byte pwdb[] = new byte[pwd.length];
-		for (int b = 0; b < pwd.length; b++) {
-			pwdb[b] = (byte) pwd[b];
-		}
-		char crypt[] = hexDump(md.digest(pwdb));
-		smudge(pwdb);
-		return crypt;
 	}
 }


### PR DESCRIPTION
migrate from MD5Crypt.crypt() to Crypt.crypt, which is more useful.  Crypt.crypt() is compatible with the algorithms supported by GNU crypt.  Also change the variable used for salting to the salt column.  The salt column should be set to the password column in jaas.config

unused cryptPassword() method from utils